### PR TITLE
Avoid erroring out on deserialization

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,5 +1,5 @@
 name: Tests
-on: [push]
+on: [push pull_request]
 
 jobs:
   build:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,5 +1,11 @@
 name: Tests
-on: [push pull_request]
+on:
+  push:
+    branches:
+    - main
+  pull_request:
+    branches:
+    - main
 
 jobs:
   build:

--- a/fvalues/f.py
+++ b/fvalues/f.py
@@ -88,6 +88,10 @@ class F(str):
             return F(s, (s,))
 
         assert isinstance(ex.node, ast.Call)
+
+        if len(ex.node.args) > 1:
+            return F(s, (s,))  # possible deserialization call
+
         [arg] = ex.node.args
         return F(s, F._parts_from_node(arg, ex, s))
 

--- a/tests/test_f.py
+++ b/tests/test_f.py
@@ -1,5 +1,7 @@
 import time
 from copy import deepcopy
+from typing import Any
+from typing import Dict
 
 import pytest
 
@@ -284,3 +286,18 @@ def test_join_bad_source():
     s = F.join(F(","), strings)
     assert s == "a,b,c"
     assert s.parts == s.flatten().parts == ("a", ",", "b", ",", "c")
+
+
+def test_deserialization():
+    # pyyaml deserialization reconstructs F with multiple arguments:
+    # https://github.com/yaml/pyyaml/blob/957ae4d/lib/yaml/constructor.py#L591
+    # make sure that there is no error resulting from this
+    cls = F
+    args = ["test_str"]
+    kwds: Dict[str, Any] = {}
+    # copied straight from pyyaml, so ignore mypy complaints
+    new_f = cls.__new__(cls, *args, **kwds)  # type: ignore
+    # during deserialization, the state of the object will be updated after
+    # construction anyways, so there's no need to check for anything other than
+    # successful object creation
+    assert new_f == "test_str"


### PR DESCRIPTION
[As seen here](https://github.com/yaml/pyyaml/blob/957ae4d495cf8fcb5475c6c2f1bce801096b68a5/lib/yaml/constructor.py#L591), the YAML deserializer constructs Python objects generically with the code:

```python
        if newobj and isinstance(cls, type):
            return cls.__new__(cls, *args, **kwds)
```

This causes `F.__new__` to error out because it's only expecting a single arg. In such a case, let's

- avoid erroring out
- save on computation by just constructing the string without any parts, because the YAML deserializer is going to just overwrite the state of the FValue right afterwards anyways