### PR TITLE
Add option for preserving non-F strings when joining

### DIFF
--- a/fvalues/f.py
+++ b/fvalues/f.py
@@ -303,10 +303,10 @@ class F(str):
             else:
                 parts.append(item)
         return F(str(self).join(map(str, iterable)), tuple(parts))
-    
+
     def preserved_join(self, iterable: Iterable[str]) -> "F":
         """Join strings while preserving regular strings.
-        
+
         Normally, joined strings will all become FValues. However, sometimes we want
         to preserve them as regular strings instead of FValues. This function allows
         for that option.
@@ -330,7 +330,6 @@ class F(str):
             parts.pop()
 
         return F(joined, parts=tuple(parts))
-
 
 
 def get_frame() -> FrameType:

--- a/fvalues/f.py
+++ b/fvalues/f.py
@@ -303,6 +303,34 @@ class F(str):
             else:
                 parts.append(item)
         return F(str(self).join(map(str, iterable)), tuple(parts))
+    
+    def preserved_join(self, iterable: Iterable[str]) -> "F":
+        """Join strings while preserving regular strings.
+        
+        Normally, joined strings will all become FValues. However, sometimes we want
+        to preserve them as regular strings instead of FValues. This function allows
+        for that option.
+        """
+        joined = ""
+        parts = []
+        for substring in iterable:
+            joined += substring
+            if isinstance(substring, F):
+                parts.extend(list(substring.parts))
+            else:  # regular string, keep as such
+                parts.append(substring)
+
+            # avoid polluting parts when joining with empty string
+            if str(self) != "":
+                joined += self
+                parts.append(self)
+
+        if len(parts) > 0 and str(self) != "":  # pop the last joiner
+            joined = joined[: -len(self)]
+            parts.pop()
+
+        return F(joined, parts=tuple(parts))
+
 
 
 def get_frame() -> FrameType:

--- a/fvalues/f.py
+++ b/fvalues/f.py
@@ -315,10 +315,7 @@ class F(str):
         parts = []
         for substring in iterable:
             joined += substring
-            if isinstance(substring, F):
-                parts.extend(list(substring.parts))
-            else:  # regular string, keep as such
-                parts.append(substring)
+            parts.append(substring)
 
             # avoid polluting parts when joining with empty string
             if str(self) != "":

--- a/tests/test_f.py
+++ b/tests/test_f.py
@@ -301,7 +301,7 @@ def test_preserved_join_list():
         "a",
         " ",
         "b=",
-        FValue(source='b', value=2, formatted="2"),
+        FValue(source="b", value=2, formatted="2"),
         " ",
         "c",
     )
@@ -322,7 +322,7 @@ def test_preserved_join_empty_string():
     assert s.parts == (
         "a",
         "b=",
-        FValue(source='b', value=2, formatted="2"),
+        FValue(source="b", value=2, formatted="2"),
         "c",
     )
     assert s.flatten().parts == (

--- a/tests/test_f.py
+++ b/tests/test_f.py
@@ -300,8 +300,7 @@ def test_preserved_join_list():
     assert s.parts == (
         "a",
         " ",
-        "b=",
-        FValue(source="b", value=2, formatted="2"),
+        F(f"b={b}", parts=("b=", FValue(source="b", value=2, formatted="2"))),
         " ",
         "c",
     )
@@ -321,8 +320,7 @@ def test_preserved_join_empty_string():
     assert s == "ab=2c"
     assert s.parts == (
         "a",
-        "b=",
-        FValue(source="b", value=2, formatted="2"),
+        F(f"b={b}", parts=("b=", FValue(source="b", value=2, formatted="2"))),
         "c",
     )
     assert s.flatten().parts == (

--- a/tests/test_f.py
+++ b/tests/test_f.py
@@ -288,6 +288,51 @@ def test_join_bad_source():
     assert s.parts == s.flatten().parts == ("a", ",", "b", ",", "c")
 
 
+def test_preserved_join_empty():
+    s = F(" ").preserved_join([])
+    assert s == F("", parts=("",))
+
+
+def test_preserved_join_list():
+    b = 2
+    s = F(" ").preserved_join(["a", F(f"b={b}"), "c"])
+    assert s == "a b=2 c"
+    assert s.parts == (
+        "a",
+        " ",
+        "b=",
+        FValue(source='b', value=2, formatted="2"),
+        " ",
+        "c",
+    )
+    assert s.flatten().parts == (
+        "a",
+        " ",
+        "b=",
+        FValue(source="b", value=2, formatted="2"),
+        " ",
+        "c",
+    )
+
+
+def test_preserved_join_empty_string():
+    b = 2
+    s = F("").preserved_join(["a", F(f"b={b}"), "c"])
+    assert s == "ab=2c"
+    assert s.parts == (
+        "a",
+        "b=",
+        FValue(source='b', value=2, formatted="2"),
+        "c",
+    )
+    assert s.flatten().parts == (
+        "a",
+        "b=",
+        FValue(source="b", value=2, formatted="2"),
+        "c",
+    )
+
+
 def test_deserialization():
     # pyyaml deserialization reconstructs F with multiple arguments:
     # https://github.com/yaml/pyyaml/blob/957ae4d/lib/yaml/constructor.py#L591


### PR DESCRIPTION
Currently, whenever I join pure strings, the whole thing gets highlighted. I would prefer for there to be an option where this is not the case.

If you're okay with modifying the existing `join` function, I can certainly try to change that instead.